### PR TITLE
Fix issue with git-fork script

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -3,11 +3,11 @@
 # Add remote upsteam
 # USAGE: git-fork <original-author>
 
-local user=$1
+user=$1
 if [[ "$user" == "" ]]
 then
   echo "Usage: git-fork <original-author>"
 else
-  local repo=`basename "$(pwd)"`
+  repo=`basename "$(pwd)"`
   git remote add upstream "https://github.com/$user/$repo.git"
 fi


### PR DESCRIPTION
Just removed `local` vars declaration (because `local` can be used inside functions only).
<img width="842" alt="git-fork" src="https://cloud.githubusercontent.com/assets/1968098/16648842/9e14a164-443e-11e6-9f96-402af8a5b8c7.png">
