### PR TITLE
fix update_apt command not found

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -125,7 +125,7 @@ main() {
   on_start "$*"
   update_dotfiles "$*"
   update_brew "$*"
-  update_apt "$*"
+  update_apt_get "$*"
   on_finish "$*"
 }
 


### PR DESCRIPTION
command not found error on calling `update_apt` - method is defined at L#85 using `update_apt_get` instead

Screenshot of the output from running the `update` script
![Screenshot from 2024-03-31 14-41-43](https://github.com/denysdovhan/dotfiles/assets/23464327/cf9c074a-c29e-4f15-a255-b75a6ba4b1e6)
