### PR TITLE
Add mise plugin

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -138,6 +138,7 @@ if ! zgen saved; then
     zgen oh-my-zsh plugins/bun
     zgen oh-my-zsh plugins/tldr
     zgen oh-my-zsh plugins/fzf
+    zgen oh-my-zsh plugins/mise
 
     # Like cd but with z-zsh capabilities
     if command -v zoxide >/dev/null 2>&1; then

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -82,13 +82,14 @@ fi
 # Better ls with icons, tree view and more
 # https://github.com/eza-community/eza
 if _exists eza; then
-  unalias ls
+  unalias ls 2>/dev/null
   alias ls='eza --icons --header --git --hyperlink'
   alias lt='eza --icons --tree'
-  unalias l
+  unalias l 2>/dev/null
   alias l='ls -l'
   alias la='ls -lAh'
 fi
+
 
 # cat with syntax highlighting
 # https://github.com/sharkdp/bat


### PR DESCRIPTION
This PR improves shell ergonomics by enabling the mise Oh My Zsh plugin and making the existing ls/l alias setup more defensive.

### Changes
adds plugins/mise to the zgen-managed Oh My Zsh plugin list in .zshrc
updates unalias ls and unalias l in [aliases.zsh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to suppress errors when those aliases are not already defined
### Why
the mise plugin adds shell support for mise in the existing Zsh plugin setup
suppressing unalias errors makes shell startup cleaner and avoids noisy output on machines or shells where those aliases are not present yet